### PR TITLE
Update CI_code_completion/CI_phpStorm.php

### DIFF
--- a/CI_code_completion/CI_phpStorm.php
+++ b/CI_code_completion/CI_phpStorm.php
@@ -69,6 +69,7 @@
  */
 class CI_Controller extends my_models
 {
+  public function __construct() {} //This default return construct as set
 }
 
 /**
@@ -116,4 +117,5 @@ class CI_Controller extends my_models
  */
 class CI_Model
 {
+  public function __construct() {} //This default return construct as set
 }


### PR DESCRIPTION
I have idea add "public function __construct() {} to CI_Controller and CI_Model after this addition everithg work and phpstorm didnt announce "missing contructor in CI_Controller or CI_Model"; 
