### PR TITLE
Change CI_Model to also extend my_models

### DIFF
--- a/CodeIgniter/CI_phpStorm.php
+++ b/CodeIgniter/CI_phpStorm.php
@@ -119,7 +119,7 @@ class CI_Controller extends my_models
  * @property CI_Driver_Library $driver            CodeIgniter Driver Library Class
  * @property CI_Cache $cache                      CodeIgniter Caching Class
  */
-class CI_Model
+class CI_Model extends my_models
 {
   public function __construct() {} //This default return construct as set
 }


### PR DESCRIPTION
Models extend CI_Model but not CI_Controller. This change allows auto completion of custom methods in models, exactly the same as controllers.