### PR TITLE
PhpStorm plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: generic
+script:
+- cp -r ./CodeIgniter plugins/CodeIgniter/
+- cd plugins/CodeIgniter/
+- zip -r ../../codeigniter-code-completion-helper-$TRAVIS_TAG.jar *
+- cd ../../
+- cp -r ./OpenCart plugins/OpenCart/
+- cd plugins/OpenCart/
+- zip -r ../../opencart-code-completion-helper-$TRAVIS_TAG.jar *
+- cd ../../
+- cp -r ./WordPress plugins/WordPress/
+- cd plugins/WordPress/
+- zip -r ../../wordpress-code-completion-helper-$TRAVIS_TAG.jar *
+- cd ../../
+deploy:
+  provider: releases
+  api_key:
+    secure: i4dz9LUINPOh0W9ZFJJr3x+LP3okb0OZ9DbqsquOx/KShz9VGalWUjbO/Pw2S48MBAcJmI9p16J5LfCnIIx5fM02yOBigCSFHCnfPFHC4ID7Ke4BmaM2OmGXFRmrnmG9xDDSPAeOpvnbau6xkg0Wr8Y1znfNOgGmZOpteb0nwdekZHnf/TQW8XtwnBKDt+s1YwGZH0xbeF7fTcMZUZm5YefeXjKBGjKcPvG69cl1Vv7jKei1fOUkW4EBxXDRXYErES0OoNmw0fdpKwkMfeQ4jyMJ3vTkvqiLHOuFhFvKWbWSRZU/Eyu+KitkCCLoxq4UGn1vkvNrEu6tLywkiGfjGS8GUn766YVucYQzPqpUc+4brrM7TgbETyGnYMeYPxzIPFwwjkbUu6TRbUtzArtkaLfzkg9qEFHINohuhLNBCmfjMj1DwM/5LuO5eh+cB4qG0Pa2RCVa6rkCunb9BSvl1NefkJCFjbALPvngghFqlSmdPqJ9ZmZ3zXZGODNTgUdZJLhheC7i9BYlwjioy3iOUjnEVCt6jQHfvFAGWP7I2R9phGATMoCOepD2r/MriRhmVETdJjvGsbvHJohuvsN/dX4LYF0VnJKV8r7Wo7Ox83Ag825pHe0SwO5AclkAxVSuqrXXn9W0Cb2o/BIk2GCfhquvO60/yZnQz6HJcHwFJFY=
+  file:
+  - codeigniter-code-completion-helper-$TRAVIS_TAG.jar
+  - opencart-code-completion-helper-$TRAVIS_TAG.jar
+  - wordpress-code-completion-helper-$TRAVIS_TAG.jar
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Code Completion for OSS projects in phpStorm
 ===========================================
 
+[![Build Status](https://travis-ci.org/artspb/phpStorm-CC-Helpers.svg?branch=master)](https://travis-ci.org/artspb/phpStorm-CC-Helpers)
+
 #### These are helper files for code completion in phpStorm with some Open Source Software that I work with.
 
 Its important that you read the comments in each file.

--- a/plugins/CodeIgniter/META-INF/plugin.xml
+++ b/plugins/CodeIgniter/META-INF/plugin.xml
@@ -1,0 +1,27 @@
+<idea-plugin version="2">
+    <id>me.artpsb.idea.plugin.codeigniter.code.completion.helper</id>
+    <name>CodeIgniter Code Completion Helper</name>
+    <version>1.0</version>
+    <vendor email="contact@artspb.me" url="https://artspb.me">Artem Khvastunov</vendor>
+
+    <description><![CDATA[
+    Provides code completion support for CodeIgniter.
+  ]]></description>
+
+    <change-notes><![CDATA[
+    <h3>1.0</h3>
+    <ul>
+      <li>Initial support.</li>
+    </ul>
+  ]]>
+    </change-notes>
+
+    <idea-version since-build="163.3984"/>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.jetbrains.php</depends>
+
+    <extensions defaultExtensionNs="com.jetbrains.php">
+        <libraryRoot id="CodeIgniter" path="/CodeIgniter/" runtime="false"/>
+    </extensions>
+</idea-plugin>

--- a/plugins/OpenCart/META-INF/plugin.xml
+++ b/plugins/OpenCart/META-INF/plugin.xml
@@ -1,0 +1,27 @@
+<idea-plugin version="2">
+    <id>me.artpsb.idea.plugin.opencart.code.completion.helper</id>
+    <name>OpenCart Code Completion Helper</name>
+    <version>1.0</version>
+    <vendor email="contact@artspb.me" url="https://artspb.me">Artem Khvastunov</vendor>
+
+    <description><![CDATA[
+    Provides code completion support for OpenCart.
+  ]]></description>
+
+    <change-notes><![CDATA[
+    <h3>1.0</h3>
+    <ul>
+      <li>Initial support.</li>
+    </ul>
+  ]]>
+    </change-notes>
+
+    <idea-version since-build="163.3984"/>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.jetbrains.php</depends>
+
+    <extensions defaultExtensionNs="com.jetbrains.php">
+        <libraryRoot id="OpenCart" path="/OpenCart/" runtime="false"/>
+    </extensions>
+</idea-plugin>

--- a/plugins/WordPress/META-INF/plugin.xml
+++ b/plugins/WordPress/META-INF/plugin.xml
@@ -1,0 +1,27 @@
+<idea-plugin version="2">
+    <id>me.artpsb.idea.plugin.wordpress.code.completion.helper</id>
+    <name>WordPress Code Completion Helper</name>
+    <version>1.0</version>
+    <vendor email="contact@artspb.me" url="https://artspb.me">Artem Khvastunov</vendor>
+
+    <description><![CDATA[
+    Provides code completion support for WordPress.
+  ]]></description>
+
+    <change-notes><![CDATA[
+    <h3>1.0</h3>
+    <ul>
+      <li>Initial support.</li>
+    </ul>
+  ]]>
+    </change-notes>
+
+    <idea-version since-build="163.3984"/>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.jetbrains.php</depends>
+
+    <extensions defaultExtensionNs="com.jetbrains.php">
+        <libraryRoot id="WordPress" path="/WordPress/" runtime="false"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
The pull request provides ability to build PhpStorm plugins on top of already existing helpers. The build process is fully automated and done by Travis CI. [Here](https://github.com/artspb/phpStorm-CC-Helpers/releases) you can see how does it look like.

Note: plugins work only in PhpStorm 2016.3 EAP which will be delivered later this week.

To configure your repository you need to:
0. Merge the pull request.
1. Create a build job on [Travis CI](https://travis-ci.org/).
2. [Generate](https://docs.travis-ci.com/user/deployment/releases/) new `api_key` and replace old one in `.travis.yml`. To do this I prefer to use a console client (`travis setup releases`) because it generates the key and encrypts it in one simple step.
3. Update the button in `README.md`.

After that the build job will upload plugins to each new tag.

Optionally you can update `<id>` and `<vendor>` tags in `plugin.xml` files and upload plugins to the [JetBrains plugin repository](https://plugins.jetbrains.com/). I'd be really grateful if you do this.
